### PR TITLE
Feature/partial results extraction

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="zulu-11" project-jdk-type="JavaSDK" />
 </project>

--- a/src/main/kotlin/com/github/sua/extraction/DashboardExtraction.kt
+++ b/src/main/kotlin/com/github/sua/extraction/DashboardExtraction.kt
@@ -1,0 +1,69 @@
+package com.github.sua.extraction
+
+import com.github.sua.extraction.extractor.dashboard.DashboardExtractor
+import com.github.sua.extraction.extractor.dashboard.DashboardExtractorRequest
+import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractor
+import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractorRequest
+import com.github.sua.extraction.extractor.login.*
+import com.github.sua.usecase.dto.input.DashboardExtractionInput
+
+class DashboardExtraction(
+    private val cookieExtractor: CookieExtractor,
+    private val loginExtractor: LoginExtractor,
+    private val loginRedirectExtractor: LoginRedirectExtractor,
+    private val dashboardRedirectExtractor: DashboardRedirectExtractor,
+    private val dashboardExtractor: DashboardExtractor,
+) {
+
+    fun extract(input: DashboardExtractionInput, resultPageType: String): DashboardExtractionResponse {
+        val cookieExtractorResponse = cookieExtractor.extract()
+
+        val loginExtractorResponse = loginExtractor.extract(
+            LoginExtractorRequest(
+                sessionId = cookieExtractorResponse.sessionId,
+                endpoint = cookieExtractorResponse.endpoint,
+                studentCpf = input.sigaCredential.cpf,
+                studentPassword = input.sigaCredential.password,
+                viewState = cookieExtractorResponse.viewState
+            )
+        )
+
+        val loginRedirectExtractorResponse = loginRedirectExtractor.extract(
+            LoginRedirectExtractorRequest(
+                sessionId = cookieExtractorResponse.sessionId,
+                endpoint = loginExtractorResponse.endpoint
+            )
+        )
+
+        val dashboardRedirectResponse = dashboardRedirectExtractor.extract(
+            DashboardRedirectExtractorRequest(
+                sessionId = cookieExtractorResponse.sessionId,
+                viewState = loginRedirectExtractorResponse.viewState
+            )
+        )
+
+        val dashboardResponse = dashboardExtractor.extract(
+            DashboardExtractorRequest(
+                endpoint = dashboardRedirectResponse.endpoint,
+                sessionId = cookieExtractorResponse.sessionId,
+                etts = loginRedirectExtractorResponse.etts,
+            ),
+            resultPageType = resultPageType
+        )
+
+        return DashboardExtractionResponse(
+            studentName = dashboardResponse.studentName,
+            dashboardResponseEndpoint = dashboardResponse.endpoint,
+            cookieExtractorResponseSessionId = cookieExtractorResponse.sessionId,
+            loginRedirectExtractorResponseEtts = loginRedirectExtractorResponse.etts,
+        )
+    }
+
+}
+
+data class DashboardExtractionResponse(
+    val studentName: String,
+    val dashboardResponseEndpoint: String,
+    val cookieExtractorResponseSessionId: String,
+    val loginRedirectExtractorResponseEtts: String
+)

--- a/src/main/kotlin/com/github/sua/extraction/DefaultPartialResultsExtraction.kt
+++ b/src/main/kotlin/com/github/sua/extraction/DefaultPartialResultsExtraction.kt
@@ -9,6 +9,7 @@ import com.github.sua.extraction.extractor.results.semester.*
 import com.github.sua.extraction.extractor.results.*
 import com.github.sua.extraction.extractor.results.partial.*
 import com.github.sua.extraction.extractor.results.partial.dto.StudentPartialResults
+import com.github.sua.extraction.parser.dashboard.DashboardParser.Companion.PARTIAL_RESULT_PAGE
 import com.github.sua.usecase.dto.input.PartialResultsInput
 import com.github.sua.usecase.extraction.PartialResultsExtraction
 
@@ -53,7 +54,8 @@ class DefaultPartialResultsExtraction(
                 endpoint = dashboardRedirectResponse.endpoint,
                 sessionId = cookieExtractorResponse.sessionId,
                 etts = loginRedirectExtractorResponse.etts,
-            )
+            ),
+         pageType = PARTIAL_RESULT_PAGE
         )
 
         val dashboardPartialResultsExtractorResponse = dashboardPartialResultsExtractor.extract(
@@ -84,7 +86,7 @@ class DefaultPartialResultsExtraction(
         ) ?: throw Exception("Invalid course identified")
 
         val subjectIdentified = getSigaIdentifiedBy(
-            content = input.course,
+            content = input.subject,
             items = partialResultsResponse.subjectsIdentified
         ) ?: throw Exception("Invalid subject identified")
 

--- a/src/main/kotlin/com/github/sua/extraction/DefaultPartialResultsExtraction.kt
+++ b/src/main/kotlin/com/github/sua/extraction/DefaultPartialResultsExtraction.kt
@@ -1,99 +1,51 @@
 package com.github.sua.extraction
 
-import com.github.sua.extraction.extractor.dashboard.DashboardExtractor
-import com.github.sua.extraction.extractor.dashboard.DashboardExtractorRequest
-import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractor
-import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractorRequest
-import com.github.sua.extraction.extractor.login.*
-import com.github.sua.extraction.extractor.results.semester.*
-import com.github.sua.extraction.extractor.results.*
 import com.github.sua.extraction.extractor.results.partial.*
 import com.github.sua.extraction.extractor.results.partial.dto.StudentPartialResults
+import com.github.sua.extraction.misc.utils.getIdentifiedBy
 import com.github.sua.extraction.parser.dashboard.DashboardParser.Companion.PARTIAL_RESULT_PAGE
 import com.github.sua.usecase.dto.input.PartialResultsInput
 import com.github.sua.usecase.extraction.PartialResultsExtraction
 
 class DefaultPartialResultsExtraction(
-    private val cookieExtractor: CookieExtractor,
-    private val loginExtractor: LoginExtractor,
-    private val loginRedirectExtractor: LoginRedirectExtractor,
-    private val dashboardRedirectExtractor: DashboardRedirectExtractor,
-    private val dashboardExtractor: DashboardExtractor,
+    private val dashboardExtraction: DashboardExtraction,
     private val dashboardPartialResultsExtractor: DashboardPartialResultsExtractor,
     private val partialResultsExtractor: PartialResultsExtractor,
     private val partialResultsByPeriodExtractor: PartialResultsByPeriodExtractor
 ) : PartialResultsExtraction {
 
     override fun extract(input: PartialResultsInput): StudentPartialResults {
-        val cookieExtractorResponse = cookieExtractor.extract()
-        val loginExtractorResponse = loginExtractor.extract(
-            LoginExtractorRequest(
-                sessionId = cookieExtractorResponse.sessionId,
-                endpoint = cookieExtractorResponse.endpoint,
-                studentCpf = input.sigaCredential.cpf,
-                studentPassword = input.sigaCredential.password,
-                viewState = cookieExtractorResponse.viewState
-            )
-        )
-        val loginRedirectExtractorResponse = loginRedirectExtractor.extract(
-            LoginRedirectExtractorRequest(
-                sessionId = cookieExtractorResponse.sessionId,
-                endpoint = loginExtractorResponse.endpoint
-            )
-        )
-
-        val dashboardRedirectResponse = dashboardRedirectExtractor.extract(
-            DashboardRedirectExtractorRequest(
-                sessionId = cookieExtractorResponse.sessionId,
-                viewState = loginRedirectExtractorResponse.viewState
-            )
-        )
-
-        val dashboardResponse = dashboardExtractor.extract(
-            DashboardExtractorRequest(
-                endpoint = dashboardRedirectResponse.endpoint,
-                sessionId = cookieExtractorResponse.sessionId,
-                etts = loginRedirectExtractorResponse.etts,
-            ),
-         pageType = PARTIAL_RESULT_PAGE
+        val dashboardExtractionResponse = dashboardExtraction.extract(
+            input = input.toDashboardInput(),
+            resultPageType = PARTIAL_RESULT_PAGE
         )
 
         val dashboardPartialResultsExtractorResponse = dashboardPartialResultsExtractor.extract(
             DashboardPartialResultsExtractorRequest(
-                endpoint = dashboardResponse.endpoint,
-                sessionId = cookieExtractorResponse.sessionId,
-                etts = loginRedirectExtractorResponse.etts
+                endpoint = dashboardExtractionResponse.dashboardResponseEndpoint,
+                sessionId = dashboardExtractionResponse.cookieExtractorResponseSessionId,
+                etts = dashboardExtractionResponse.loginRedirectExtractorResponseEtts
             )
         )
 
         val partialResultsResponse = partialResultsExtractor.extract(
             PartialResultsExtractorRequest(
                 endpoint = dashboardPartialResultsExtractorResponse.endpoint,
-                sessionId = cookieExtractorResponse.sessionId,
-                etts = loginRedirectExtractorResponse.etts
+                sessionId = dashboardExtractionResponse.cookieExtractorResponseSessionId,
+                etts = dashboardExtractionResponse.loginRedirectExtractorResponseEtts
             )
         )
 
-        val periodIdentified = getPeriodSigaIdentified(
-            year = input.period.year,
-            term = input.period.term,
-            periods = partialResultsResponse.periodsIdentified
-        ) ?: throw Exception("Invalid period identified")
-
-        val courseIdentified = getSigaIdentifiedBy(
-            content = input.course,
-            items = partialResultsResponse.coursesIdentified
-        ) ?: throw Exception("Invalid course identified")
-
-        val subjectIdentified = getSigaIdentifiedBy(
-            content = input.subject,
-            items = partialResultsResponse.subjectsIdentified
-        ) ?: throw Exception("Invalid subject identified")
+        val periodIdentified = partialResultsResponse.periodsIdentified.getIdentifiedBy(
+            key = "${input.period.year}/${input.period.term}"
+        )
+        val courseIdentified = partialResultsResponse.coursesIdentified.getIdentifiedBy(key= input.course)
+        val subjectIdentified = partialResultsResponse.subjectsIdentified.getIdentifiedBy(key = input.subject)
 
         val partialResultsByPeriodExtractorResponse = partialResultsByPeriodExtractor.extract(
             PartialResultsByPeriodExtractorRequest(
                 sessionId = partialResultsResponse.sessionId,
-                etts = loginRedirectExtractorResponse.etts,
+                etts = dashboardExtractionResponse.loginRedirectExtractorResponseEtts,
                 periodIdentified = periodIdentified,
                 courseIdentified = courseIdentified,
                 subjectIdentified = subjectIdentified
@@ -101,13 +53,9 @@ class DefaultPartialResultsExtraction(
         )
 
         return StudentPartialResults(
-            studentName = dashboardResponse.studentName,
+            studentName = dashboardExtractionResponse.studentName,
             partialResults = partialResultsByPeriodExtractorResponse.partialResults
         )
     }
-
-    private fun getPeriodSigaIdentified(year: String, term: Int, periods: Map<String, String>) = periods["$year/$term"]
-
-    private fun getSigaIdentifiedBy(content: String, items: Map<String, String>) = items[content]
 
 }

--- a/src/main/kotlin/com/github/sua/extraction/DefaultPartialResultsExtraction.kt
+++ b/src/main/kotlin/com/github/sua/extraction/DefaultPartialResultsExtraction.kt
@@ -1,0 +1,111 @@
+package com.github.sua.extraction
+
+import com.github.sua.extraction.extractor.dashboard.DashboardExtractor
+import com.github.sua.extraction.extractor.dashboard.DashboardExtractorRequest
+import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractor
+import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractorRequest
+import com.github.sua.extraction.extractor.login.*
+import com.github.sua.extraction.extractor.results.semester.*
+import com.github.sua.extraction.extractor.results.*
+import com.github.sua.extraction.extractor.results.partial.*
+import com.github.sua.extraction.extractor.results.partial.dto.StudentPartialResults
+import com.github.sua.usecase.dto.input.PartialResultsInput
+import com.github.sua.usecase.extraction.PartialResultsExtraction
+
+class DefaultPartialResultsExtraction(
+    private val cookieExtractor: CookieExtractor,
+    private val loginExtractor: LoginExtractor,
+    private val loginRedirectExtractor: LoginRedirectExtractor,
+    private val dashboardRedirectExtractor: DashboardRedirectExtractor,
+    private val dashboardExtractor: DashboardExtractor,
+    private val dashboardPartialResultsExtractor: DashboardPartialResultsExtractor,
+    private val partialResultsExtractor: PartialResultsExtractor,
+    private val partialResultsByPeriodExtractor: PartialResultsByPeriodExtractor
+) : PartialResultsExtraction {
+
+    override fun extract(input: PartialResultsInput): StudentPartialResults {
+        val cookieExtractorResponse = cookieExtractor.extract()
+        val loginExtractorResponse = loginExtractor.extract(
+            LoginExtractorRequest(
+                sessionId = cookieExtractorResponse.sessionId,
+                endpoint = cookieExtractorResponse.endpoint,
+                studentCpf = input.sigaCredential.cpf,
+                studentPassword = input.sigaCredential.password,
+                viewState = cookieExtractorResponse.viewState
+            )
+        )
+        val loginRedirectExtractorResponse = loginRedirectExtractor.extract(
+            LoginRedirectExtractorRequest(
+                sessionId = cookieExtractorResponse.sessionId,
+                endpoint = loginExtractorResponse.endpoint
+            )
+        )
+
+        val dashboardRedirectResponse = dashboardRedirectExtractor.extract(
+            DashboardRedirectExtractorRequest(
+                sessionId = cookieExtractorResponse.sessionId,
+                viewState = loginRedirectExtractorResponse.viewState
+            )
+        )
+
+        val dashboardResponse = dashboardExtractor.extract(
+            DashboardExtractorRequest(
+                endpoint = dashboardRedirectResponse.endpoint,
+                sessionId = cookieExtractorResponse.sessionId,
+                etts = loginRedirectExtractorResponse.etts,
+            )
+        )
+
+        val dashboardPartialResultsExtractorResponse = dashboardPartialResultsExtractor.extract(
+            DashboardPartialResultsExtractorRequest(
+                endpoint = dashboardResponse.endpoint,
+                sessionId = cookieExtractorResponse.sessionId,
+                etts = loginRedirectExtractorResponse.etts
+            )
+        )
+
+        val partialResultsResponse = partialResultsExtractor.extract(
+            PartialResultsExtractorRequest(
+                endpoint = dashboardPartialResultsExtractorResponse.endpoint,
+                sessionId = cookieExtractorResponse.sessionId,
+                etts = loginRedirectExtractorResponse.etts
+            )
+        )
+
+        val periodIdentified = getPeriodSigaIdentified(
+            year = input.period.year,
+            term = input.period.term,
+            periods = partialResultsResponse.periodsIdentified
+        ) ?: throw Exception("Invalid period identified")
+
+        val courseIdentified = getSigaIdentifiedBy(
+            content = input.course,
+            items = partialResultsResponse.coursesIdentified
+        ) ?: throw Exception("Invalid course identified")
+
+        val subjectIdentified = getSigaIdentifiedBy(
+            content = input.course,
+            items = partialResultsResponse.subjectsIdentified
+        ) ?: throw Exception("Invalid subject identified")
+
+        val partialResultsByPeriodExtractorResponse = partialResultsByPeriodExtractor.extract(
+            PartialResultsByPeriodExtractorRequest(
+                sessionId = partialResultsResponse.sessionId,
+                etts = loginRedirectExtractorResponse.etts,
+                periodIdentified = periodIdentified,
+                courseIdentified = courseIdentified,
+                subjectIdentified = subjectIdentified
+            )
+        )
+
+        return StudentPartialResults(
+            studentName = dashboardResponse.studentName,
+            partialResults = partialResultsByPeriodExtractorResponse.partialResults
+        )
+    }
+
+    private fun getPeriodSigaIdentified(year: String, term: Int, periods: Map<String, String>) = periods["$year/$term"]
+
+    private fun getSigaIdentifiedBy(content: String, items: Map<String, String>) = items[content]
+
+}

--- a/src/main/kotlin/com/github/sua/extraction/DefaultSemesterResultsExtraction.kt
+++ b/src/main/kotlin/com/github/sua/extraction/DefaultSemesterResultsExtraction.kt
@@ -5,8 +5,9 @@ import com.github.sua.extraction.extractor.dashboard.DashboardExtractorRequest
 import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractor
 import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractorRequest
 import com.github.sua.extraction.extractor.login.*
-import com.github.sua.extraction.extractor.semesterresults.*
-import com.github.sua.extraction.extractor.semesterresults.dto.StudentSemesterResults
+import com.github.sua.extraction.extractor.results.semester.*
+import com.github.sua.extraction.extractor.results.*
+import com.github.sua.extraction.extractor.results.semester.dto.StudentSemesterResults
 import com.github.sua.usecase.dto.input.SemesterResultsInput
 import com.github.sua.usecase.extraction.SemesterResultsExtraction
 

--- a/src/main/kotlin/com/github/sua/extraction/DefaultSemesterResultsExtraction.kt
+++ b/src/main/kotlin/com/github/sua/extraction/DefaultSemesterResultsExtraction.kt
@@ -1,98 +1,57 @@
 package com.github.sua.extraction
 
-import com.github.sua.extraction.extractor.dashboard.DashboardExtractor
-import com.github.sua.extraction.extractor.dashboard.DashboardExtractorRequest
-import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractor
-import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractorRequest
-import com.github.sua.extraction.extractor.login.*
 import com.github.sua.extraction.extractor.results.semester.*
-import com.github.sua.extraction.extractor.results.*
 import com.github.sua.extraction.extractor.results.semester.dto.StudentSemesterResults
+import com.github.sua.extraction.misc.utils.getIdentifiedBy
 import com.github.sua.extraction.parser.dashboard.DashboardParser.Companion.SEMESTER_RESULT_PAGE
 import com.github.sua.usecase.dto.input.SemesterResultsInput
 import com.github.sua.usecase.extraction.SemesterResultsExtraction
 
 class DefaultSemesterResultsExtraction(
-    private val cookieExtractor: CookieExtractor,
-    private val loginExtractor: LoginExtractor,
-    private val loginRedirectExtractor: LoginRedirectExtractor,
-    private val dashboardRedirectExtractor: DashboardRedirectExtractor,
-    private val dashboardExtractor: DashboardExtractor,
+    private val dashboardExtraction: DashboardExtraction,
     private val dashboardSemesterResultsExtractor: DashboardSemesterResultsExtractor,
     private val semesterResultsExtractor: SemesterResultsExtractor,
     private val semesterResultsByPeriodExtractor: SemesterResultsByPeriodExtractor
 ) : SemesterResultsExtraction {
 
     override fun extract(input: SemesterResultsInput): StudentSemesterResults {
-        val cookieExtractorResponse = cookieExtractor.extract()
-        val loginExtractorResponse = loginExtractor.extract(
-            LoginExtractorRequest(
-                sessionId = cookieExtractorResponse.sessionId,
-                endpoint = cookieExtractorResponse.endpoint,
-                studentCpf = input.sigaCredential.cpf,
-                studentPassword = input.sigaCredential.password,
-                viewState = cookieExtractorResponse.viewState
-            )
-        )
-        val loginRedirectExtractorResponse = loginRedirectExtractor.extract(
-            LoginRedirectExtractorRequest(
-                sessionId = cookieExtractorResponse.sessionId,
-                endpoint = loginExtractorResponse.endpoint
-            )
-        )
-
-        val dashboardRedirectResponse = dashboardRedirectExtractor.extract(
-            DashboardRedirectExtractorRequest(
-                sessionId = cookieExtractorResponse.sessionId,
-                viewState = loginRedirectExtractorResponse.viewState
-            )
-        )
-
-        val dashboardResponse = dashboardExtractor.extract(
-            DashboardExtractorRequest(
-                endpoint = dashboardRedirectResponse.endpoint,
-                sessionId = cookieExtractorResponse.sessionId,
-                etts = loginRedirectExtractorResponse.etts,
-            ),
-           pageType =  SEMESTER_RESULT_PAGE
+        val dashboardExtractionResponse = dashboardExtraction.extract(
+            input = input.toDashboardInput(),
+            resultPageType = SEMESTER_RESULT_PAGE
         )
 
         val dashboardSemesterResultsExtractorResponse = dashboardSemesterResultsExtractor.extract(
             DashboardSemesterResultsExtractorRequest(
-                endpoint = dashboardResponse.endpoint,
-                sessionId = cookieExtractorResponse.sessionId,
-                etts = loginRedirectExtractorResponse.etts
+                endpoint = dashboardExtractionResponse.dashboardResponseEndpoint,
+                sessionId = dashboardExtractionResponse.cookieExtractorResponseSessionId,
+                etts = dashboardExtractionResponse.loginRedirectExtractorResponseEtts
             )
         )
 
         val semesterResultsResponse = semesterResultsExtractor.extract(
             SemesterResultsExtractorRequest(
                 endpoint = dashboardSemesterResultsExtractorResponse.endpoint,
-                sessionId = cookieExtractorResponse.sessionId,
-                etts = loginRedirectExtractorResponse.etts
+                sessionId = dashboardExtractionResponse.cookieExtractorResponseSessionId,
+                etts = dashboardExtractionResponse.loginRedirectExtractorResponseEtts
             )
         )
 
-        val periodIdentified = getPeriodSigaIdentified(
-            year = input.period.year,
-            term = input.period.term,
-            periods = semesterResultsResponse.periodIdentified
-        ) ?: throw Exception("Invalid period identified")
+        val periodIdentified = semesterResultsResponse.periodsIdentified.getIdentifiedBy(
+            key = "${input.period.year}/${input.period.term}"
+        )
 
         val semesterResultsByPeriodExtractorResponse = semesterResultsByPeriodExtractor.extract(
             SemesterResultsByPeriodExtractorRequest(
                 sessionId = semesterResultsResponse.sessionId,
-                etts = loginRedirectExtractorResponse.etts,
+                etts = dashboardExtractionResponse.loginRedirectExtractorResponseEtts,
                 periodIdentified = periodIdentified
             )
         )
 
         return StudentSemesterResults(
-            studentName = dashboardResponse.studentName,
+            studentName = dashboardExtractionResponse.studentName,
             semesterResults = semesterResultsByPeriodExtractorResponse.semesterResults.toSemesterResultsPeriod()
         )
     }
-
-    private fun getPeriodSigaIdentified(year: String, term: Int, periods: Map<String, String>) = periods["$year/$term"]
 
 }

--- a/src/main/kotlin/com/github/sua/extraction/DefaultSemesterResultsExtraction.kt
+++ b/src/main/kotlin/com/github/sua/extraction/DefaultSemesterResultsExtraction.kt
@@ -8,6 +8,7 @@ import com.github.sua.extraction.extractor.login.*
 import com.github.sua.extraction.extractor.results.semester.*
 import com.github.sua.extraction.extractor.results.*
 import com.github.sua.extraction.extractor.results.semester.dto.StudentSemesterResults
+import com.github.sua.extraction.parser.dashboard.DashboardParser.Companion.SEMESTER_RESULT_PAGE
 import com.github.sua.usecase.dto.input.SemesterResultsInput
 import com.github.sua.usecase.extraction.SemesterResultsExtraction
 
@@ -52,7 +53,8 @@ class DefaultSemesterResultsExtraction(
                 endpoint = dashboardRedirectResponse.endpoint,
                 sessionId = cookieExtractorResponse.sessionId,
                 etts = loginRedirectExtractorResponse.etts,
-            )
+            ),
+           pageType =  SEMESTER_RESULT_PAGE
         )
 
         val dashboardSemesterResultsExtractorResponse = dashboardSemesterResultsExtractor.extract(

--- a/src/main/kotlin/com/github/sua/extraction/extractor/dashboard/DashboardExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/dashboard/DashboardExtractor.kt
@@ -10,11 +10,11 @@ class DashboardExtractor(
     private val dashboardParser: DashboardParser
 ) {
 
-    fun extract(request: DashboardExtractorRequest, pageType: String): DashboardExtractorResponse {
+    fun extract(request: DashboardExtractorRequest, resultPageType: String): DashboardExtractorResponse {
         return when (val response = dashboardStep.doRequest(request)) {
             is StepSuccess -> DashboardExtractorResponse(
                 studentName = dashboardParser.extractStudentName(response.payload),
-                endpoint = dashboardParser.extractDashboardActionPageUrl(response.payload, pageType)
+                endpoint = dashboardParser.extractDashboardActionPageUrl(response.payload, resultPageType)
             )
             else -> throw ExtractorException("Dashboard extractor unexpected error")
         }

--- a/src/main/kotlin/com/github/sua/extraction/extractor/dashboard/DashboardExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/dashboard/DashboardExtractor.kt
@@ -10,11 +10,11 @@ class DashboardExtractor(
     private val dashboardParser: DashboardParser
 ) {
 
-    fun extract(request: DashboardExtractorRequest): DashboardExtractorResponse {
+    fun extract(request: DashboardExtractorRequest, pageType: String): DashboardExtractorResponse {
         return when (val response = dashboardStep.doRequest(request)) {
             is StepSuccess -> DashboardExtractorResponse(
                 studentName = dashboardParser.extractStudentName(response.payload),
-                endpoint = dashboardParser.extractDashboardSemesterResultsUrl(response.payload)
+                endpoint = dashboardParser.extractDashboardActionPageUrl(response.payload, pageType)
             )
             else -> throw ExtractorException("Dashboard extractor unexpected error")
         }
@@ -32,3 +32,4 @@ data class DashboardExtractorResponse(
     val studentName: String,
     val endpoint: String
 )
+

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/DashboardPartialResultsExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/DashboardPartialResultsExtractor.kt
@@ -1,0 +1,32 @@
+package com.github.sua.extraction.extractor.results.partial
+
+import com.github.sua.extraction.exception.ExtractorException
+import com.github.sua.extraction.parser.semesterresults.PartialResultsParser
+import com.github.sua.extraction.step.StepResponse.StepSuccess
+import com.github.sua.extraction.step.results.partial.DashboardPartialResultsStep
+
+class DashboardPartialResultsExtractor(
+    private val dashboardPartialResultsStep: DashboardPartialResultsStep,
+    private val partialResultsParser: PartialResultsParser
+) {
+
+    fun extract(request: DashboardPartialResultsExtractorRequest): DashboardPartialResultsExtractorResponse {
+        return when (val response =dashboardPartialResultsStep.doRequest(request)){
+            is StepSuccess -> DashboardPartialResultsExtractorResponse(
+                endpoint =partialResultsParser.extractSemesterResultsUrl(response.payload)
+            )
+            else -> throw ExtractorException("Partial results extractor unexpected error")
+        }
+    }
+
+}
+
+data class DashboardPartialResultsExtractorRequest(
+    val endpoint: String,
+    val sessionId: String,
+    val etts: String
+)
+
+data class DashboardPartialResultsExtractorResponse(
+    val endpoint: String
+)

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/DashboardPartialResultsExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/DashboardPartialResultsExtractor.kt
@@ -11,9 +11,9 @@ class DashboardPartialResultsExtractor(
 ) {
 
     fun extract(request: DashboardPartialResultsExtractorRequest): DashboardPartialResultsExtractorResponse {
-        return when (val response =dashboardPartialResultsStep.doRequest(request)){
+        return when (val response = dashboardPartialResultsStep.doRequest(request)){
             is StepSuccess -> DashboardPartialResultsExtractorResponse(
-                endpoint =partialResultsParser.extractSemesterResultsUrl(response.payload)
+                endpoint = partialResultsParser.extractPartialResultsUrl(response.payload)
             )
             else -> throw ExtractorException("Partial results extractor unexpected error")
         }

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsByPeriodExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsByPeriodExtractor.kt
@@ -1,0 +1,42 @@
+package com.github.sua.extraction.extractor.results.partial
+
+import com.github.sua.extraction.exception.ExtractorException
+import com.github.sua.extraction.extractor.results.partial.dto.PartialResults
+import com.github.sua.extraction.parser.semesterresults.PartialResultsParser
+import com.github.sua.extraction.parser.semesterresults.SemesterResultsParser
+import com.github.sua.extraction.step.StepResponse.StepSuccess
+import com.github.sua.extraction.step.results.partial.PartialResultsByPeriodStep
+import com.github.sua.extraction.step.results.semester.SemesterResultsByPeriodStep
+
+class PartialResultsByPeriodExtractor(
+    private val partialResultsByPeriodStep: PartialResultsByPeriodStep,
+    private val partialResultsParser: PartialResultsParser
+) {
+
+    fun extract(request: PartialResultsByPeriodExtractorRequest): PartialResultsByPeriodExtractorResponse {
+        return when (val response = partialResultsByPeriodStep.doRequest(request)) {
+            is StepSuccess -> PartialResultsByPeriodExtractorResponse(
+                partialResults = partialResultsParser.extractPartialResults(
+                    response.payload,
+                    request.periodIdentified,
+                    request.courseIdentified,
+                    request.subjectIdentified,
+                )
+            )
+            else -> throw ExtractorException("Partial results extractor unexpected error")
+        }
+    }
+
+}
+
+data class PartialResultsByPeriodExtractorRequest(
+    val sessionId: String,
+    val etts: String,
+    val periodIdentified: String,
+    val courseIdentified: String,
+    val subjectIdentified: String
+)
+
+data class PartialResultsByPeriodExtractorResponse(
+    val partialResults: PartialResults,
+)

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractor.kt
@@ -1,0 +1,34 @@
+package com.github.sua.extraction.extractor.results.partial
+
+import com.github.sua.extraction.exception.ExtractorException
+import com.github.sua.extraction.parser.semesterresults.PartialResultsParser
+import com.github.sua.extraction.step.StepResponse.StepSuccess
+import com.github.sua.extraction.step.results.partial.PartialResultsStep
+
+class PartialResultsExtractor(
+    private val partialResultsStep: PartialResultsStep,
+    private val partialResultsParser: PartialResultsParser
+) {
+
+    fun extract(request: PartialResultsExtractorRequest): PartialResultsExtractorResponse {
+        return when (val response = partialResultsStep.doRequest(request)) {
+            is StepSuccess -> PartialResultsExtractorResponse(
+                sessionId = response.getSessionId(position = 0),
+                periodsIdentified = partialResultsParser.extractPeriodsIdentified(response.payload)
+            )
+            else -> throw ExtractorException("Partial results extractor unexpected error")
+        }
+    }
+
+}
+
+data class PartialResultsExtractorRequest(
+    val endpoint: String,
+    val sessionId: String,
+    val etts: String,
+)
+
+data class PartialResultsExtractorResponse(
+    val sessionId: String,
+    val periodsIdentified: Map<String, String>,
+)

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractor.kt
@@ -16,7 +16,7 @@ class PartialResultsExtractor(
                 sessionId = response.getSessionId(position = 0),
                 periodsIdentified = partialResultsParser.extractPeriodsIdentified(response.payload),
                 coursesIdentified = partialResultsParser.extractCourses(response.payload),
-                subjectsIdentified = partialResultsParser.extractSubjects(response.payload)
+                subjectsIdentified =  partialResultsParser.extractSubjects(response.payload)
             )
             else -> throw ExtractorException("Partial results extractor unexpected error")
         }

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractor.kt
@@ -14,7 +14,9 @@ class PartialResultsExtractor(
         return when (val response = partialResultsStep.doRequest(request)) {
             is StepSuccess -> PartialResultsExtractorResponse(
                 sessionId = response.getSessionId(position = 0),
-                periodsIdentified = partialResultsParser.extractPeriodsIdentified(response.payload)
+                periodsIdentified = partialResultsParser.extractPeriodsIdentified(response.payload),
+                coursesIdentified = partialResultsParser.extractCourses(response.payload),
+                subjectsIdentified = partialResultsParser.extractSubjects(response.payload)
             )
             else -> throw ExtractorException("Partial results extractor unexpected error")
         }
@@ -31,4 +33,6 @@ data class PartialResultsExtractorRequest(
 data class PartialResultsExtractorResponse(
     val sessionId: String,
     val periodsIdentified: Map<String, String>,
+    val coursesIdentified: Map<String, String>,
+    val subjectsIdentified: Map<String, String>,
 )

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/dto/PartialResultsExtractorResponse.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/dto/PartialResultsExtractorResponse.kt
@@ -13,7 +13,7 @@ data class PartialResults(
     val period: String,
     val course: String,
     val subjectName: String,
-    val partialResults: List<PartialResult>
+    val results: List<PartialResult>
 )
 
 @Serializable

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/dto/PartialResultsExtractorResponse.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/partial/dto/PartialResultsExtractorResponse.kt
@@ -1,0 +1,26 @@
+package com.github.sua.extraction.extractor.results.partial.dto
+
+import kotlinx.serialization.*
+
+@Serializable
+data class StudentPartialResults(
+    val studentName: String,
+    val partialResults: PartialResults
+)
+
+@Serializable
+data class PartialResults(
+    val period: String,
+    val course: String,
+    val subjectName: String,
+    val partialResults: List<PartialResult>
+)
+
+@Serializable
+data class PartialResult(
+    val code: String,
+    val resultName: String,
+    val date: String,
+    val classLoad: Double,
+    val result: Double,
+)

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/DashboardSemesterResultsExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/DashboardSemesterResultsExtractor.kt
@@ -1,9 +1,9 @@
-package com.github.sua.extraction.extractor.semesterresults
+package com.github.sua.extraction.extractor.results.semester
 
 import com.github.sua.extraction.exception.ExtractorException
 import com.github.sua.extraction.parser.semesterresults.SemesterResultsParser
 import com.github.sua.extraction.step.StepResponse.StepSuccess
-import com.github.sua.extraction.step.semesterresults.DashboardSemesterResultsStep
+import com.github.sua.extraction.step.results.semester.DashboardSemesterResultsStep
 
 class DashboardSemesterResultsExtractor(
     private val dashboardSemesterResultsStep: DashboardSemesterResultsStep,

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/SemesterResultsByPeriodExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/SemesterResultsByPeriodExtractor.kt
@@ -1,9 +1,9 @@
-package com.github.sua.extraction.extractor.semesterresults
+package com.github.sua.extraction.extractor.results.semester
 
 import com.github.sua.extraction.exception.ExtractorException
 import com.github.sua.extraction.parser.semesterresults.SemesterResultsParser
 import com.github.sua.extraction.step.StepResponse.StepSuccess
-import com.github.sua.extraction.step.semesterresults.SemesterResultsByPeriodStep
+import com.github.sua.extraction.step.results.semester.SemesterResultsByPeriodStep
 
 class SemesterResultsByPeriodExtractor(
     private val semesterResultsByPeriodStep: SemesterResultsByPeriodStep,

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/SemesterResultsExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/SemesterResultsExtractor.kt
@@ -14,7 +14,7 @@ class SemesterResultsExtractor(
         return when (val response = semesterResultStep.doRequest(request)) {
             is StepSuccess -> SemesterResultsExtractorResponse(
                 sessionId = response.getSessionId(position = 0),
-                periodIdentified = semesterResultsParser.extractPeriods(response.payload)
+                periodsIdentified = semesterResultsParser.extractPeriods(response.payload)
             )
             else -> throw ExtractorException("Semester results extractor unexpected error")
         }
@@ -30,5 +30,5 @@ data class SemesterResultsExtractorRequest(
 
 data class SemesterResultsExtractorResponse(
     val sessionId: String,
-    val periodIdentified: Map<String, String>,
+    val periodsIdentified: Map<String, String>,
 )

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/SemesterResultsExtractor.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/SemesterResultsExtractor.kt
@@ -1,9 +1,9 @@
-package com.github.sua.extraction.extractor.semesterresults
+package com.github.sua.extraction.extractor.results.semester
 
 import com.github.sua.extraction.exception.ExtractorException
 import com.github.sua.extraction.parser.semesterresults.SemesterResultsParser
 import com.github.sua.extraction.step.StepResponse.StepSuccess
-import com.github.sua.extraction.step.semesterresults.SemesterResultsStep
+import com.github.sua.extraction.step.results.semester.SemesterResultsStep
 
 class SemesterResultsExtractor(
     private val semesterResultStep: SemesterResultsStep,

--- a/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/dto/SemesterResultsExtractorResponse.kt
+++ b/src/main/kotlin/com/github/sua/extraction/extractor/results/semester/dto/SemesterResultsExtractorResponse.kt
@@ -1,4 +1,4 @@
-package com.github.sua.extraction.extractor.semesterresults.dto
+package com.github.sua.extraction.extractor.results.semester.dto
 
 import kotlinx.serialization.*
 

--- a/src/main/kotlin/com/github/sua/extraction/misc/utils/ExtractionExtensions.kt
+++ b/src/main/kotlin/com/github/sua/extraction/misc/utils/ExtractionExtensions.kt
@@ -1,0 +1,5 @@
+package com.github.sua.extraction.misc.utils
+
+fun Map<String, String>.getIdentifiedBy(key: String): String {
+    return this[key] ?: throw Exception("Invalid $key identified")
+}

--- a/src/main/kotlin/com/github/sua/extraction/parser/dashboard/DashboardParser.kt
+++ b/src/main/kotlin/com/github/sua/extraction/parser/dashboard/DashboardParser.kt
@@ -5,13 +5,13 @@ import org.jsoup.Jsoup
 
 class DashboardParser {
 
-    fun extractDashboardSemesterResultsUrl(responseContent: String): String {
+    fun extractDashboardActionPageUrl(responseContent: String, pageType:String): String {
         val document = Jsoup.parse(responseContent)
-        val li = document.getElementById("formMenu:menu_3_3") ?: throw ParserException("Invalid document id")
+        val elementId = getElementIdByPageType(pageType)
+        val li = document.getElementById(elementId) ?: throw ParserException("Invalid document id")
         val a = li.children()
         return a.attr("href").substringAfter("/")
     }
-
     fun extractSemesterResultsUrl(responseContent: String): String {
         val document = Jsoup.parse(responseContent)
         val input = document.getElementById("formPrincipal:linkAbre") ?: throw ParserException("Invalid document id")
@@ -22,6 +22,17 @@ class DashboardParser {
         val document = Jsoup.parse(responseContent)
         val label = document.getElementById("formMenu:j_idt111") ?: throw ParserException("Invalid document id")
         return label.text()
+    }
+
+    private fun getElementIdByPageType(pageType: String)= when(pageType){
+        SEMESTER_RESULT_PAGE -> "formMenu:menu_3_3"
+        PARTIAL_RESULT_PAGE -> "formMenu:menu_3_7"
+        else -> throw ParserException("Invalid page type $pageType")
+    }
+
+    companion object {
+        const val SEMESTER_RESULT_PAGE = "semester_result_page"
+        const val PARTIAL_RESULT_PAGE = "partial_result_page"
     }
 
 }

--- a/src/main/kotlin/com/github/sua/extraction/parser/dashboard/DashboardParser.kt
+++ b/src/main/kotlin/com/github/sua/extraction/parser/dashboard/DashboardParser.kt
@@ -5,9 +5,9 @@ import org.jsoup.Jsoup
 
 class DashboardParser {
 
-    fun extractDashboardActionPageUrl(responseContent: String, pageType:String): String {
+    fun extractDashboardActionPageUrl(responseContent: String, resultPageType:String): String {
         val document = Jsoup.parse(responseContent)
-        val elementId = getElementIdByPageType(pageType)
+        val elementId = getElementIdByPageType(resultPageType)
         val li = document.getElementById(elementId) ?: throw ParserException("Invalid document id")
         val a = li.children()
         return a.attr("href").substringAfter("/")

--- a/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/PartialResultsParser.kt
+++ b/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/PartialResultsParser.kt
@@ -17,12 +17,13 @@ class PartialResultsParser {
         val document = Jsoup.parse(responseContent)
         val termSelect = document.getElementById("lPeriodoLetivo")!!
         val courseSelect = document.getElementById("lCurso")!!
+        val subjectSelect = document.getElementById("lDisciplina")!!
         val resultSpan = document.getElementById("resultado")!!
 
         return PartialResults(
             course = extractCourse(courseSelect, courseIdentified),
             period = extractPeriod(termSelect, periodIdentified),
-            subjectName = "todo",
+            subjectName = extractSubject(subjectSelect, subjectIdentified),
             results = extractPartialResultsBy(resultSpan),
         )
     }

--- a/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/PartialResultsParser.kt
+++ b/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/PartialResultsParser.kt
@@ -1,9 +1,74 @@
 package com.github.sua.extraction.parser.semesterresults
 
 import com.github.sua.extraction.exception.ParserException
+import com.github.sua.extraction.extractor.results.partial.dto.PartialResult
+import com.github.sua.extraction.extractor.results.partial.dto.PartialResults
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
 
 class PartialResultsParser {
+
+    fun extractPartialResults(
+        responseContent: String,
+        periodIdentified: String,
+        courseIdentified: String,
+        subjectIdentified: String,
+    ): PartialResults {
+        val document = Jsoup.parse(responseContent)
+        val termSelect = document.getElementById("lPeriodoLetivo")!!
+        val courseSelect = document.getElementById("lCurso")!!
+        val subjectSelect = document.getElementById("lDisciplina")!!
+        val resultSpan = document.getElementById("resultado")!!
+
+        return PartialResults(
+            course = extractCourse(courseSelect, courseIdentified),
+            period = extractPeriod(termSelect, periodIdentified),
+            subjectName = extractSubject(subjectSelect, subjectIdentified),
+            partialResults = extractPartialResultsBy(resultSpan),
+        )
+    }
+
+    private fun extractPeriod(termSelect: Element, periodIdentified: String): String {
+        val firstTerm = termSelect.getElementsByAttributeValue("value", periodIdentified)
+        return firstTerm.text()
+    }
+
+    private fun extractSubject(termSelect: Element, periodIdentified: String): String {
+        val firstTerm = termSelect.getElementsByAttributeValue("value", periodIdentified)
+        return firstTerm.text()
+    }
+
+    private fun extractCourse(termSelect: Element, courseIdentified: String): String {
+        val firstTerm = termSelect.getElementsByAttributeValue("value", courseIdentified)
+        return firstTerm.text()
+    }
+
+    private fun extractPartialResultsBy(resultSpan: Element): MutableList<PartialResult> {
+        val table = resultSpan.select("center > table.delimitador > tbody").first()
+        val partialResults = mutableListOf<PartialResult>()
+        table?.children()?.mapIndexed { index, row ->
+            if (row.childrenSize() == 5 && index != 0 && row.getElementsContainingText("Média Parcial").size == 0) {
+                partialResults.add(extractPartialResultsData(row))
+            }
+        }
+        return partialResults
+    }
+
+    private fun extractPartialResultsData(subjectRow: Element): PartialResult {
+        val code = subjectRow.child(0).text()
+        val resultName = subjectRow.child(1).text()
+        val date = subjectRow.child(2).text()
+        val result = subjectRow.child(3).text().toDouble()
+        val classLoad = subjectRow.child(4).text().toDouble()
+
+        return PartialResult(
+            code = code,
+            resultName = resultName,
+            date = date,
+            classLoad = classLoad,
+            result = result
+        )
+    }
 
     fun extractSemesterResultsUrl(responseContent: String): String {
         val document = Jsoup.parse(responseContent)
@@ -20,6 +85,24 @@ class PartialResultsParser {
             periodMap[it.text()] = it.attr("value")
         }
         return periodMap.filter { it.key != "Extensão" }
+    }
+
+    fun extractCourses(responseContent: String): Map<String, String> {
+        val document = Jsoup.parse(responseContent)
+        val courseSelect = document.getElementById("lCurso")
+        val courses = courseSelect?.getElementsByAttribute("value")
+        return courses?.map {
+            it.text() to it.attr("value")
+        }?.toMap() ?: throw Exception("Invalid element id")
+    }
+
+    fun extractSubjects(responseContent: String): Map<String, String> {
+        val document = Jsoup.parse(responseContent)
+        val courseSelect = document.getElementById("lDisciplina")
+        val courses = courseSelect?.getElementsByAttribute("value")
+        return courses?.map {
+            it.text() to it.attr("value")
+        }?.toMap() ?: throw Exception("Invalid element id")
     }
 
 }

--- a/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/PartialResultsParser.kt
+++ b/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/PartialResultsParser.kt
@@ -17,14 +17,13 @@ class PartialResultsParser {
         val document = Jsoup.parse(responseContent)
         val termSelect = document.getElementById("lPeriodoLetivo")!!
         val courseSelect = document.getElementById("lCurso")!!
-        val subjectSelect = document.getElementById("lDisciplina")!!
         val resultSpan = document.getElementById("resultado")!!
 
         return PartialResults(
             course = extractCourse(courseSelect, courseIdentified),
             period = extractPeriod(termSelect, periodIdentified),
-            subjectName = extractSubject(subjectSelect, subjectIdentified),
-            partialResults = extractPartialResultsBy(resultSpan),
+            subjectName = "todo",
+            results = extractPartialResultsBy(resultSpan),
         )
     }
 
@@ -70,7 +69,7 @@ class PartialResultsParser {
         )
     }
 
-    fun extractSemesterResultsUrl(responseContent: String): String {
+    fun extractPartialResultsUrl(responseContent: String): String {
         val document = Jsoup.parse(responseContent)
         val input = document.getElementById("formPrincipal:linkAbre")
         return input?.attr("value")?.substringAfter("/") ?: throw ParserException("Invalid document key")
@@ -104,5 +103,6 @@ class PartialResultsParser {
             it.text() to it.attr("value")
         }?.toMap() ?: throw Exception("Invalid element id")
     }
+
 
 }

--- a/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/PartialResultsParser.kt
+++ b/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/PartialResultsParser.kt
@@ -1,0 +1,25 @@
+package com.github.sua.extraction.parser.semesterresults
+
+import com.github.sua.extraction.exception.ParserException
+import org.jsoup.Jsoup
+
+class PartialResultsParser {
+
+    fun extractSemesterResultsUrl(responseContent: String): String {
+        val document = Jsoup.parse(responseContent)
+        val input = document.getElementById("formPrincipal:linkAbre")
+        return input?.attr("value")?.substringAfter("/") ?: throw ParserException("Invalid document key")
+    }
+
+    fun extractPeriodsIdentified(responseContent: String): Map<String, String> {
+        val document = Jsoup.parse(responseContent)
+        val periodsSelect = document.getElementById("lPeriodoLetivo")
+        val periods = periodsSelect?.getElementsByAttribute("value")
+        val periodMap = mutableMapOf<String, String>()
+        periods?.map {
+            periodMap[it.text()] = it.attr("value")
+        }
+        return periodMap.filter { it.key != "Extensão" }
+    }
+
+}

--- a/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/SemesterResultsParser.kt
+++ b/src/main/kotlin/com/github/sua/extraction/parser/semesterresults/SemesterResultsParser.kt
@@ -1,7 +1,7 @@
 package com.github.sua.extraction.parser.semesterresults
 
-import com.github.sua.extraction.extractor.semesterresults.dto.SemesterResult
-import com.github.sua.extraction.extractor.semesterresults.dto.SemesterResultsResponse
+import com.github.sua.extraction.extractor.results.semester.dto.SemesterResult
+import com.github.sua.extraction.extractor.results.semester.dto.SemesterResultsResponse
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 

--- a/src/main/kotlin/com/github/sua/extraction/step/dashboard/DashboardRedirectStep.kt
+++ b/src/main/kotlin/com/github/sua/extraction/step/dashboard/DashboardRedirectStep.kt
@@ -16,10 +16,10 @@ class DashboardRedirectStep(
 
         val body = mapOf(
             "javax.faces.partial.ajax" to "true",
-            "javax.faces.source" to "formRedirect:j_idt31",
-            "javax.faces.partial.execute" to "formRedirect:j_idt31",
+            "javax.faces.source" to "formRedirect:j_idt32",
+            "javax.faces.partial.execute" to "formRedirect:j_idt32",
             "javax.faces.partial.render" to "@none",
-            "formRedirect:j_idt31" to "formRedirect:j_idt31",
+            "formRedirect:j_idt32" to "formRedirect:j_idt32",
             "formRedirect" to "formRedirect",
             "javax.faces.ViewState" to request.viewState,
         )

--- a/src/main/kotlin/com/github/sua/extraction/step/results/partial/DashboardPartialResultsStep.kt
+++ b/src/main/kotlin/com/github/sua/extraction/step/results/partial/DashboardPartialResultsStep.kt
@@ -1,0 +1,23 @@
+package com.github.sua.extraction.step.results.partial
+
+import com.github.sua.extraction.extractor.results.partial.DashboardPartialResultsExtractorRequest
+import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
+import com.github.sua.extraction.step.Step
+import com.github.sua.extraction.step.StepResponse
+
+class DashboardPartialResultsStep(
+    private val httpClient: ConnectorHttpClient
+): Step() {
+
+    fun doRequest(request: DashboardPartialResultsExtractorRequest): StepResponse{
+        val headers = mapOf(
+            "Cookie" to "${request.sessionId}; ECS=S; ${request.etts}"
+        )
+
+        return httpClient.get(
+            endpoint = request.endpoint,
+            headers = headers
+        ).getStepResponse()
+    }
+
+}

--- a/src/main/kotlin/com/github/sua/extraction/step/results/partial/PartialResultsByPeriodStep.kt
+++ b/src/main/kotlin/com/github/sua/extraction/step/results/partial/PartialResultsByPeriodStep.kt
@@ -1,0 +1,45 @@
+package com.github.sua.extraction.step.results.partial
+
+import com.github.sua.extraction.extractor.results.partial.PartialResultsByPeriodExtractorRequest
+import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
+import com.github.sua.extraction.step.Step
+import com.github.sua.extraction.step.StepResponse
+
+class PartialResultsByPeriodStep(
+    private val httpClient: ConnectorHttpClient
+) : Step() {
+
+    fun doRequest(request: PartialResultsByPeriodExtractorRequest): StepResponse {
+        val headers = mapOf(
+            "Cookie" to "${request.sessionId}; ECS=S; ${request.etts}"
+        )
+
+        val body = mapOf(
+            "lookupCorrentePlc" to "",
+            "navSetaFocoPlc" to "",
+            "modoPlc" to "consultaPlc",
+            "detCorrPlc" to "",
+            "indExcDetPlc" to "",
+            "evento" to "Executar Consulta",
+            "lPeriodoLetivo" to request.periodIdentified,
+            "lCurso" to request.courseIdentified,
+            "lDisciplina" to request.subjectIdentified,
+            "caracterSep" to "",
+            "idConsulta" to "3",
+            "exibecomp" to "N",
+            "exibeComboPerLet" to "S",
+            "nomeArquivoPdf" to ""
+        )
+
+        return httpClient.post(
+            endpoint = SEMESTER_RESULTS_BY_PERIOD_STEP_URL,
+            headers = headers,
+            body = body
+        ).getStepResponse()
+    }
+
+    companion object {
+        const val SEMESTER_RESULTS_BY_PERIOD_STEP_URL = "siga/com/executaconsultapersonaliz.do"
+    }
+
+}

--- a/src/main/kotlin/com/github/sua/extraction/step/results/partial/PartialResultsStep.kt
+++ b/src/main/kotlin/com/github/sua/extraction/step/results/partial/PartialResultsStep.kt
@@ -1,15 +1,15 @@
-package com.github.sua.extraction.step.semesterresults
+package com.github.sua.extraction.step.results.partial
 
-import com.github.sua.extraction.extractor.semesterresults.DashboardSemesterResultsExtractorRequest
+import com.github.sua.extraction.extractor.results.partial.PartialResultsExtractorRequest
 import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
 import com.github.sua.extraction.step.Step
 import com.github.sua.extraction.step.StepResponse
 
-class DashboardSemesterResultsStep(
+class PartialResultsStep(
     private val httpClient: ConnectorHttpClient
 ) : Step() {
 
-    fun doRequest(request: DashboardSemesterResultsExtractorRequest): StepResponse {
+    fun doRequest(request: PartialResultsExtractorRequest): StepResponse{
         val headers = mapOf(
             "Cookie" to "${request.sessionId}; ECS=S; ${request.etts}"
         )

--- a/src/main/kotlin/com/github/sua/extraction/step/results/semester/DashboardSemesterResultsStep.kt
+++ b/src/main/kotlin/com/github/sua/extraction/step/results/semester/DashboardSemesterResultsStep.kt
@@ -1,0 +1,23 @@
+package com.github.sua.extraction.step.results.semester
+
+import com.github.sua.extraction.extractor.results.semester.DashboardSemesterResultsExtractorRequest
+import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
+import com.github.sua.extraction.step.Step
+import com.github.sua.extraction.step.StepResponse
+
+class DashboardSemesterResultsStep(
+    private val httpClient: ConnectorHttpClient
+) : Step() {
+
+    fun doRequest(request: DashboardSemesterResultsExtractorRequest): StepResponse {
+        val headers = mapOf(
+            "Cookie" to "${request.sessionId}; ECS=S; ${request.etts}"
+        )
+
+        return httpClient.get(
+            endpoint = request.endpoint,
+            headers = headers
+        ).getStepResponse()
+    }
+
+}

--- a/src/main/kotlin/com/github/sua/extraction/step/results/semester/SemesterResultsByPeriodStep.kt
+++ b/src/main/kotlin/com/github/sua/extraction/step/results/semester/SemesterResultsByPeriodStep.kt
@@ -1,6 +1,6 @@
-package com.github.sua.extraction.step.semesterresults
+package com.github.sua.extraction.step.results.semester
 
-import com.github.sua.extraction.extractor.semesterresults.SemesterResultsByPeriodExtractorRequest
+import com.github.sua.extraction.extractor.results.semester.SemesterResultsByPeriodExtractorRequest
 import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
 import com.github.sua.extraction.step.Step
 import com.github.sua.extraction.step.StepResponse

--- a/src/main/kotlin/com/github/sua/extraction/step/results/semester/SemesterResultsStep.kt
+++ b/src/main/kotlin/com/github/sua/extraction/step/results/semester/SemesterResultsStep.kt
@@ -1,6 +1,6 @@
-package com.github.sua.extraction.step.semesterresults
+package com.github.sua.extraction.step.results.semester
 
-import com.github.sua.extraction.extractor.semesterresults.SemesterResultsExtractorRequest
+import com.github.sua.extraction.extractor.results.semester.SemesterResultsExtractorRequest
 import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
 import com.github.sua.extraction.step.Step
 import com.github.sua.extraction.step.StepResponse

--- a/src/main/kotlin/com/github/sua/http/controller/PartialResults.kt
+++ b/src/main/kotlin/com/github/sua/http/controller/PartialResults.kt
@@ -1,0 +1,35 @@
+package com.github.sua.http.controller
+
+import com.github.sua.entity.student.SigaCredential
+import com.github.sua.http.extension.getRequiredParameter
+import com.github.sua.usecase.dto.input.PartialResultsInput
+import com.github.sua.usecase.dto.input.PeriodInput
+import com.github.sua.usecase.retrieve.RetrievePartialResults
+import io.ktor.application.*
+import io.ktor.locations.*
+import io.ktor.response.*
+import io.ktor.routing.*
+
+@Location("/partial-results")
+class PartialResults
+
+fun Route.partialResults(
+    service: RetrievePartialResults
+) = get<PartialResults> {
+    val input = PartialResultsInput(
+        sigaCredential = SigaCredential(
+            cpf = call.getRequiredParameter("cpf"),
+            password = call.getRequiredParameter("password")
+        ),
+        period = PeriodInput(
+            year = call.getRequiredParameter("year"),
+            term = call.getRequiredParameter("term").toInt()
+        ),
+        course = call.getRequiredParameter("course"),
+        subject = call.getRequiredParameter("subject")
+    )
+
+    val response = service.retrieve(input)
+
+    call.respond(response)
+}

--- a/src/main/kotlin/com/github/sua/http/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/com/github/sua/http/plugins/DependencyInjection.kt
@@ -6,9 +6,9 @@ import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractor
 import com.github.sua.extraction.extractor.login.CookieExtractor
 import com.github.sua.extraction.extractor.login.LoginExtractor
 import com.github.sua.extraction.extractor.login.LoginRedirectExtractor
-import com.github.sua.extraction.extractor.semesterresults.DashboardSemesterResultsExtractor
-import com.github.sua.extraction.extractor.semesterresults.SemesterResultsByPeriodExtractor
-import com.github.sua.extraction.extractor.semesterresults.SemesterResultsExtractor
+import com.github.sua.extraction.extractor.results.semester.DashboardSemesterResultsExtractor
+import com.github.sua.extraction.extractor.results.semester.SemesterResultsByPeriodExtractor
+import com.github.sua.extraction.extractor.results.semester.SemesterResultsExtractor
 import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
 import com.github.sua.extraction.misc.httpclient.ktor.KtorHttpClient
 import com.github.sua.extraction.parser.cookie.CookieParser
@@ -19,9 +19,9 @@ import com.github.sua.extraction.step.dashboard.DashboardStep
 import com.github.sua.extraction.step.login.CookieStep
 import com.github.sua.extraction.step.login.LoginRedirectStep
 import com.github.sua.extraction.step.login.LoginStep
-import com.github.sua.extraction.step.semesterresults.DashboardSemesterResultsStep
-import com.github.sua.extraction.step.semesterresults.SemesterResultsByPeriodStep
-import com.github.sua.extraction.step.semesterresults.SemesterResultsStep
+import com.github.sua.extraction.step.results.semester.DashboardSemesterResultsStep
+import com.github.sua.extraction.step.results.semester.SemesterResultsByPeriodStep
+import com.github.sua.extraction.step.results.semester.SemesterResultsStep
 import com.github.sua.usecase.extraction.SemesterResultsExtraction
 import com.github.sua.usecase.retrieve.RetrieveSemesterResults
 import com.github.sua.usecase.retrieve.RetrieveStudentInfo

--- a/src/main/kotlin/com/github/sua/http/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/com/github/sua/http/plugins/DependencyInjection.kt
@@ -1,5 +1,6 @@
 package com.github.sua.http.plugins
 
+import com.github.sua.extraction.DashboardExtraction
 import com.github.sua.extraction.DefaultPartialResultsExtraction
 import com.github.sua.extraction.DefaultSemesterResultsExtraction
 import com.github.sua.extraction.extractor.dashboard.DashboardExtractor
@@ -78,11 +79,12 @@ val appModule = module(createdAtStart = true) {
     single { DashboardPartialResultsExtractor(get(), get()) }
     single { SemesterResultsByPeriodExtractor(get(), get()) }
     single { PartialResultsByPeriodExtractor(get(), get()) }
+    single { DashboardExtraction(get(), get(), get(), get(), get()) }
     single<SemesterResultsExtraction> {
-        DefaultSemesterResultsExtraction(get(), get(), get(), get(), get(), get(), get(), get())
+        DefaultSemesterResultsExtraction(get(), get(), get(), get())
     }
     single<PartialResultsExtraction> {
-        DefaultPartialResultsExtraction(get(), get(), get(), get(), get(), get(), get(), get())
+        DefaultPartialResultsExtraction(get(), get(), get(), get())
     }
     single { RetrieveSemesterResults(get()) }
     single { RetrievePartialResults(get()) }

--- a/src/main/kotlin/com/github/sua/http/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/com/github/sua/http/plugins/DependencyInjection.kt
@@ -1,11 +1,15 @@
 package com.github.sua.http.plugins
 
+import com.github.sua.extraction.DefaultPartialResultsExtraction
 import com.github.sua.extraction.DefaultSemesterResultsExtraction
 import com.github.sua.extraction.extractor.dashboard.DashboardExtractor
 import com.github.sua.extraction.extractor.dashboard.DashboardRedirectExtractor
 import com.github.sua.extraction.extractor.login.CookieExtractor
 import com.github.sua.extraction.extractor.login.LoginExtractor
 import com.github.sua.extraction.extractor.login.LoginRedirectExtractor
+import com.github.sua.extraction.extractor.results.partial.DashboardPartialResultsExtractor
+import com.github.sua.extraction.extractor.results.partial.PartialResultsByPeriodExtractor
+import com.github.sua.extraction.extractor.results.partial.PartialResultsExtractor
 import com.github.sua.extraction.extractor.results.semester.DashboardSemesterResultsExtractor
 import com.github.sua.extraction.extractor.results.semester.SemesterResultsByPeriodExtractor
 import com.github.sua.extraction.extractor.results.semester.SemesterResultsExtractor
@@ -13,16 +17,22 @@ import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
 import com.github.sua.extraction.misc.httpclient.ktor.KtorHttpClient
 import com.github.sua.extraction.parser.cookie.CookieParser
 import com.github.sua.extraction.parser.dashboard.DashboardParser
+import com.github.sua.extraction.parser.semesterresults.PartialResultsParser
 import com.github.sua.extraction.parser.semesterresults.SemesterResultsParser
 import com.github.sua.extraction.step.dashboard.DashboardRedirectStep
 import com.github.sua.extraction.step.dashboard.DashboardStep
 import com.github.sua.extraction.step.login.CookieStep
 import com.github.sua.extraction.step.login.LoginRedirectStep
 import com.github.sua.extraction.step.login.LoginStep
+import com.github.sua.extraction.step.results.partial.DashboardPartialResultsStep
+import com.github.sua.extraction.step.results.partial.PartialResultsByPeriodStep
+import com.github.sua.extraction.step.results.partial.PartialResultsStep
 import com.github.sua.extraction.step.results.semester.DashboardSemesterResultsStep
 import com.github.sua.extraction.step.results.semester.SemesterResultsByPeriodStep
 import com.github.sua.extraction.step.results.semester.SemesterResultsStep
+import com.github.sua.usecase.extraction.PartialResultsExtraction
 import com.github.sua.usecase.extraction.SemesterResultsExtraction
+import com.github.sua.usecase.retrieve.RetrievePartialResults
 import com.github.sua.usecase.retrieve.RetrieveSemesterResults
 import com.github.sua.usecase.retrieve.RetrieveStudentInfo
 import io.ktor.application.*
@@ -46,23 +56,34 @@ val appModule = module(createdAtStart = true) {
     single { DashboardStep(get()) }
     single { DashboardRedirectStep(get()) }
     single { SemesterResultsByPeriodStep(get()) }
+    single { PartialResultsByPeriodStep(get()) }
     single { DashboardSemesterResultsStep(get()) }
+    single { DashboardPartialResultsStep(get()) }
     single { SemesterResultsStep(get()) }
+    single { PartialResultsStep(get()) }
 
     single { CookieParser() }
     single { DashboardParser() }
     single { SemesterResultsParser() }
+    single { PartialResultsParser() }
 
     single { CookieExtractor(get(), get()) }
     single { LoginExtractor(get()) }
     single { LoginRedirectExtractor(get()) }
     single { DashboardExtractor(get(), get()) }
     single { SemesterResultsExtractor(get(), get()) }
+    single { PartialResultsExtractor(get(), get()) }
     single { DashboardRedirectExtractor(get()) }
     single { DashboardSemesterResultsExtractor(get(), get()) }
+    single { DashboardPartialResultsExtractor(get(), get()) }
     single { SemesterResultsByPeriodExtractor(get(), get()) }
+    single { PartialResultsByPeriodExtractor(get(), get()) }
     single<SemesterResultsExtraction> {
         DefaultSemesterResultsExtraction(get(), get(), get(), get(), get(), get(), get(), get())
     }
+    single<PartialResultsExtraction> {
+        DefaultPartialResultsExtraction(get(), get(), get(), get(), get(), get(), get(), get())
+    }
     single { RetrieveSemesterResults(get()) }
+    single { RetrievePartialResults(get()) }
 }

--- a/src/main/kotlin/com/github/sua/http/plugins/Routing.kt
+++ b/src/main/kotlin/com/github/sua/http/plugins/Routing.kt
@@ -1,8 +1,10 @@
 package com.github.sua.http.plugins
 
 import com.github.sua.http.controller.healthCheck
+import com.github.sua.http.controller.partialResults
 import com.github.sua.http.controller.semesterResults
 import com.github.sua.http.controller.studentInfo
+import com.github.sua.usecase.retrieve.RetrievePartialResults
 import com.github.sua.usecase.retrieve.RetrieveSemesterResults
 import com.github.sua.usecase.retrieve.RetrieveStudentInfo
 import io.ktor.application.*
@@ -18,10 +20,12 @@ fun Application.configureRouting() {
 
     val retrieveStudentInfo by inject<RetrieveStudentInfo>()
     val retrieveSemesterResults by inject<RetrieveSemesterResults>()
+    val retrievePartialResults by inject<RetrievePartialResults>()
 
     routing {
         healthCheck()
         studentInfo(retrieveStudentInfo)
         semesterResults(retrieveSemesterResults)
+        partialResults(retrievePartialResults)
     }
 }

--- a/src/main/kotlin/com/github/sua/usecase/dto/input/DashboardExtractionInput.kt
+++ b/src/main/kotlin/com/github/sua/usecase/dto/input/DashboardExtractionInput.kt
@@ -1,0 +1,7 @@
+package com.github.sua.usecase.dto.input
+
+import com.github.sua.entity.student.SigaCredential
+
+data class DashboardExtractionInput(
+    val sigaCredential: SigaCredential,
+)

--- a/src/main/kotlin/com/github/sua/usecase/dto/input/PartialResultsInput.kt
+++ b/src/main/kotlin/com/github/sua/usecase/dto/input/PartialResultsInput.kt
@@ -1,0 +1,10 @@
+package com.github.sua.usecase.dto.input
+
+import com.github.sua.entity.student.SigaCredential
+
+data class PartialResultsInput(
+    val sigaCredential: SigaCredential,
+    val period: PeriodInput,
+    val course: String,
+    val subject: String,
+)

--- a/src/main/kotlin/com/github/sua/usecase/dto/input/PartialResultsInput.kt
+++ b/src/main/kotlin/com/github/sua/usecase/dto/input/PartialResultsInput.kt
@@ -7,4 +7,8 @@ data class PartialResultsInput(
     val period: PeriodInput,
     val course: String,
     val subject: String,
-)
+){
+    fun toDashboardInput() = DashboardExtractionInput(
+        sigaCredential = sigaCredential
+    )
+}

--- a/src/main/kotlin/com/github/sua/usecase/dto/input/SemesterResultsInput.kt
+++ b/src/main/kotlin/com/github/sua/usecase/dto/input/SemesterResultsInput.kt
@@ -5,4 +5,10 @@ import com.github.sua.entity.student.SigaCredential
 data class SemesterResultsInput(
     val sigaCredential: SigaCredential,
     val period: PeriodInput
-)
+){
+
+    fun toDashboardInput() = DashboardExtractionInput(
+        sigaCredential = sigaCredential
+    )
+
+}

--- a/src/main/kotlin/com/github/sua/usecase/extraction/PartialResultsExtraction.kt
+++ b/src/main/kotlin/com/github/sua/usecase/extraction/PartialResultsExtraction.kt
@@ -1,0 +1,11 @@
+package com.github.sua.usecase.extraction
+
+import com.github.sua.extraction.extractor.results.partial.dto.StudentPartialResults
+import com.github.sua.usecase.dto.input.PartialResultsInput
+
+
+interface PartialResultsExtraction {
+
+    fun extract(input: PartialResultsInput): StudentPartialResults
+
+}

--- a/src/main/kotlin/com/github/sua/usecase/extraction/SemesterResultsExtraction.kt
+++ b/src/main/kotlin/com/github/sua/usecase/extraction/SemesterResultsExtraction.kt
@@ -1,6 +1,6 @@
 package com.github.sua.usecase.extraction
 
-import com.github.sua.extraction.extractor.semesterresults.dto.StudentSemesterResults
+import com.github.sua.extraction.extractor.results.semester.dto.StudentSemesterResults
 import com.github.sua.usecase.dto.input.SemesterResultsInput
 
 

--- a/src/main/kotlin/com/github/sua/usecase/retrieve/RetrievePartialResults.kt
+++ b/src/main/kotlin/com/github/sua/usecase/retrieve/RetrievePartialResults.kt
@@ -1,0 +1,18 @@
+package com.github.sua.usecase.retrieve
+
+import com.github.sua.extraction.extractor.results.partial.dto.StudentPartialResults
+import com.github.sua.extraction.extractor.results.semester.dto.StudentSemesterResults
+import com.github.sua.usecase.dto.input.PartialResultsInput
+import com.github.sua.usecase.dto.input.SemesterResultsInput
+import com.github.sua.usecase.extraction.PartialResultsExtraction
+import com.github.sua.usecase.extraction.SemesterResultsExtraction
+
+class RetrievePartialResults(
+    private val partialResultsExtraction: PartialResultsExtraction
+) {
+
+    fun retrieve(input: PartialResultsInput): StudentPartialResults {
+        return partialResultsExtraction.extract(input)
+    }
+
+}

--- a/src/main/kotlin/com/github/sua/usecase/retrieve/RetrieveSemesterResults.kt
+++ b/src/main/kotlin/com/github/sua/usecase/retrieve/RetrieveSemesterResults.kt
@@ -1,6 +1,6 @@
 package com.github.sua.usecase.retrieve
 
-import com.github.sua.extraction.extractor.semesterresults.dto.StudentSemesterResults
+import com.github.sua.extraction.extractor.results.semester.dto.StudentSemesterResults
 import com.github.sua.usecase.dto.input.SemesterResultsInput
 import com.github.sua.usecase.extraction.SemesterResultsExtraction
 

--- a/src/test/kotlin/com/github/sua/extraction/extractor/cookie/CookieExtractorTest.kt
+++ b/src/test/kotlin/com/github/sua/extraction/extractor/cookie/CookieExtractorTest.kt
@@ -29,7 +29,6 @@ class CookieExtractorTest {
 
     }
 
-
     @Test
     fun `should throw ExtractorException when cookie step fails`() {
         val payload = "error"

--- a/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/DashboardPartialResultsExtractorTest.kt
+++ b/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/DashboardPartialResultsExtractorTest.kt
@@ -37,7 +37,7 @@ class DashboardPartialResultsExtractorTest {
             payload = payload,
             headers = emptyMap()
         )
-        every { partialResultsParser.extractSemesterResultsUrl(payload) } returns semesterResultsUrl
+        every { partialResultsParser.extractPartialResultsUrl(payload) } returns semesterResultsUrl
 
         val expected = DashboardPartialResultsExtractorResponse(
             endpoint = semesterResultsUrl,
@@ -76,7 +76,7 @@ class DashboardPartialResultsExtractorTest {
             payload = payload,
             headers = emptyMap()
         )
-        every { partialResultsParser.extractSemesterResultsUrl(payload) } throws ParserException("parse exception")
+        every { partialResultsParser.extractPartialResultsUrl(payload) } throws ParserException("parse exception")
 
         assertThrows(ParserException::class.java) {
             dashboardPartialResultsExtractor.extract(request)

--- a/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/DashboardPartialResultsExtractorTest.kt
+++ b/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/DashboardPartialResultsExtractorTest.kt
@@ -1,0 +1,87 @@
+package com.github.sua.extraction.extractor.results.partial
+
+import com.github.sua.extraction.exception.ExtractorException
+import com.github.sua.extraction.exception.ParserException
+import com.github.sua.extraction.step.StepResponse.StepError
+import com.github.sua.extraction.step.StepResponse.StepSuccess
+import com.github.sua.extraction.parser.semesterresults.PartialResultsParser
+import com.github.sua.extraction.step.results.partial.DashboardPartialResultsStep
+import org.junit.Assert.assertThrows
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import org.junit.Test
+
+
+class DashboardPartialResultsExtractorTest {
+
+    private val dashboardPartialResultsStep: DashboardPartialResultsStep = mockk()
+    private val partialResultsParser: PartialResultsParser = mockk()
+    private val dashboardPartialResultsExtractor = DashboardPartialResultsExtractor(
+        dashboardPartialResultsStep,
+        partialResultsParser
+    )
+
+    @Test
+    fun `should extract and return a valid output`() {
+        val payload = "response_success"
+        val semesterResultsUrl = "semesterResultsUrl"
+
+        val request = DashboardPartialResultsExtractorRequest(
+            endpoint = "endpoint",
+            sessionId = "sessionId",
+            etts = "etts"
+        )
+
+        every { dashboardPartialResultsStep.doRequest(request) } returns StepSuccess(
+            payload = payload,
+            headers = emptyMap()
+        )
+        every { partialResultsParser.extractSemesterResultsUrl(payload) } returns semesterResultsUrl
+
+        val expected = DashboardPartialResultsExtractorResponse(
+            endpoint = semesterResultsUrl,
+        )
+        val actual = dashboardPartialResultsExtractor.extract(request)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should throw ExtractorException when dashboard partial results step fails`() {
+        val payload = "error"
+        val request = DashboardPartialResultsExtractorRequest(
+            endpoint = "endpoint",
+            sessionId = "sessionId",
+            etts = "etts"
+        )
+
+        every { dashboardPartialResultsStep.doRequest(request) } returns StepError(payload = payload)
+
+        assertThrows(ExtractorException::class.java) {
+            dashboardPartialResultsExtractor.extract(request)
+        }
+    }
+
+    @Test
+    fun `should throw ParseException when partial results parser fails`() {
+        val payload = "success with invalid format"
+        val request = DashboardPartialResultsExtractorRequest(
+            endpoint = "endpoint",
+            sessionId = "sessionId",
+            etts = "etts"
+        )
+
+        every { dashboardPartialResultsStep.doRequest(request) } returns StepSuccess(
+            payload = payload,
+            headers = emptyMap()
+        )
+        every { partialResultsParser.extractSemesterResultsUrl(payload) } throws ParserException("parse exception")
+
+        assertThrows(ParserException::class.java) {
+            dashboardPartialResultsExtractor.extract(request)
+        }
+    }
+
+
+}

--- a/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractorTest.kt
+++ b/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractorTest.kt
@@ -40,7 +40,9 @@ class PartialResultsExtractorTest {
 
         val expected = PartialResultsExtractorResponse(
             sessionId = sessionId,
-            periodsIdentified = emptyMap()
+            periodsIdentified = emptyMap(),
+            coursesIdentified = partialResultsParser.extractCourses(response.payload),
+            subjectsIdentified = partialResultsParser.extractSubjects(response.payload)
         )
         val actual = partialResultsExtractor.extract(request)
 

--- a/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractorTest.kt
+++ b/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractorTest.kt
@@ -35,7 +35,7 @@ class PartialResultsExtractorTest {
             payload = payload,
             headers = emptyMap()
         )
-        every { partialResultsParser.extractSemesterResultsUrl(payload) } returns sessionId
+        every { partialResultsParser.extractPartialResultsUrl(payload) } returns sessionId
         every { partialResultsParser.extractPeriodsIdentified(payload) } returns emptyMap()
 
         val expected = PartialResultsExtractorResponse(
@@ -78,7 +78,7 @@ class PartialResultsExtractorTest {
             payload = payload,
             headers = emptyMap()
         )
-        every { partialResultsParser.extractSemesterResultsUrl(payload) } throws ParserException("parse exception")
+        every { partialResultsParser.extractPartialResultsUrl(payload) } throws ParserException("parse exception")
 
         Assert.assertThrows(ParserException::class.java) {
             partialResultsExtractor.extract(request)

--- a/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractorTest.kt
+++ b/src/test/kotlin/com/github/sua/extraction/extractor/results/partial/PartialResultsExtractorTest.kt
@@ -1,0 +1,86 @@
+package com.github.sua.extraction.extractor.results.partial
+
+import com.github.sua.extraction.exception.ExtractorException
+import com.github.sua.extraction.exception.ParserException
+import com.github.sua.extraction.parser.semesterresults.PartialResultsParser
+import com.github.sua.extraction.step.StepResponse
+import com.github.sua.extraction.step.results.partial.PartialResultsStep
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class PartialResultsExtractorTest {
+
+    private val partialResultsStep: PartialResultsStep = mockk()
+    private val partialResultsParser: PartialResultsParser = mockk()
+    private val partialResultsExtractor = PartialResultsExtractor(
+        partialResultsStep,
+        partialResultsParser
+    )
+
+    @Test
+    fun `should extract and return a valid output`() {
+        val payload = "response_success"
+        val sessionId = "sessionId"
+
+        val request = PartialResultsExtractorRequest(
+            endpoint = "endpoint",
+            sessionId = "sessionId",
+            etts = "etts"
+        )
+
+        every { partialResultsStep.doRequest(request) } returns StepResponse.StepSuccess(
+            payload = payload,
+            headers = emptyMap()
+        )
+        every { partialResultsParser.extractSemesterResultsUrl(payload) } returns sessionId
+        every { partialResultsParser.extractPeriodsIdentified(payload) } returns emptyMap()
+
+        val expected = PartialResultsExtractorResponse(
+            sessionId = sessionId,
+            periodsIdentified = emptyMap()
+        )
+        val actual = partialResultsExtractor.extract(request)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should throw ExtractorException when partial results step fails`() {
+        val payload = "error"
+        val request = PartialResultsExtractorRequest(
+            endpoint = "endpoint",
+            sessionId = "sessionId",
+            etts = "etts"
+        )
+
+        every { partialResultsStep.doRequest(request) } returns StepResponse.StepError(payload = payload)
+
+        Assert.assertThrows(ExtractorException::class.java) {
+            partialResultsExtractor.extract(request)
+        }
+    }
+
+    @Test
+    fun `should throw ParseException when partial results parser fails`() {
+        val payload = "success with invalid format"
+        val request = PartialResultsExtractorRequest(
+            endpoint = "endpoint",
+            sessionId = "sessionId",
+            etts = "etts"
+        )
+
+        every { partialResultsStep.doRequest(request) } returns StepResponse.StepSuccess(
+            payload = payload,
+            headers = emptyMap()
+        )
+        every { partialResultsParser.extractSemesterResultsUrl(payload) } throws ParserException("parse exception")
+
+        Assert.assertThrows(ParserException::class.java) {
+            partialResultsExtractor.extract(request)
+        }
+    }
+
+}

--- a/src/test/kotlin/com/github/sua/extraction/step/results/partial/DashboardPartialResultsStepTest.kt
+++ b/src/test/kotlin/com/github/sua/extraction/step/results/partial/DashboardPartialResultsStepTest.kt
@@ -1,0 +1,73 @@
+package com.github.sua.extraction.step.results.partial
+
+import com.github.sua.extraction.extractor.results.partial.DashboardPartialResultsExtractorRequest
+import com.github.sua.extraction.step.StepResponse.StepError
+import com.github.sua.extraction.step.StepResponse.StepSuccess
+import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
+import com.github.sua.extraction.misc.httpclient.ConnectorHttpResponse
+import io.mockk.every
+import io.mockk.mockk
+import java.net.HttpURLConnection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+
+class DashboardPartialResultsStepTest {
+
+    private val httpClient: ConnectorHttpClient = mockk()
+    private val step = DashboardPartialResultsStep(httpClient)
+
+    @Test
+    fun `should return StepSuccess when execute successfully`(){
+        every {
+            httpClient.get(endpoint = "endpoint", headers = defaultHeaders)
+        } returns ConnectorHttpResponse(
+            responseContentType = null,
+            statusCode = HttpURLConnection.HTTP_OK,
+            headers = emptyMap(),
+            body = "SUCCESS RESPONSE",
+            isSuccessful = true
+        )
+
+        val expected = StepSuccess(payload = "SUCCESS RESPONSE", headers = emptyMap())
+        val actual = step.doRequest(
+            DashboardPartialResultsExtractorRequest(
+                endpoint = "endpoint",
+                sessionId = "sessionId",
+                etts = "etts"
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should return StepError when not execute successfully`() {
+        every {
+            httpClient.get(endpoint = "endpoint", headers = defaultHeaders)
+        } returns ConnectorHttpResponse(
+            responseContentType = null,
+            statusCode = HttpURLConnection.HTTP_BAD_REQUEST,
+            headers = emptyMap(),
+            body = "ERROR RESPONSE",
+            isSuccessful = false
+        )
+
+        val expected = StepError(payload = "ERROR RESPONSE")
+        val actual = step.doRequest(
+            DashboardPartialResultsExtractorRequest(
+                endpoint = "endpoint",
+                sessionId = "sessionId",
+                etts = "etts"
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    companion object {
+        val defaultHeaders = mapOf(
+            "Cookie" to "sessionId; ECS=S; etts",
+        )
+    }
+}

--- a/src/test/kotlin/com/github/sua/extraction/step/results/partial/PartialResultsStepTest.kt
+++ b/src/test/kotlin/com/github/sua/extraction/step/results/partial/PartialResultsStepTest.kt
@@ -1,0 +1,74 @@
+package com.github.sua.extraction.step.results.partial
+
+import com.github.sua.extraction.extractor.results.partial.PartialResultsExtractorRequest
+import com.github.sua.extraction.step.StepResponse.StepError
+import com.github.sua.extraction.step.StepResponse.StepSuccess
+import com.github.sua.extraction.misc.httpclient.ConnectorHttpClient
+import com.github.sua.extraction.misc.httpclient.ConnectorHttpResponse
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import java.net.HttpURLConnection
+import kotlin.test.Test
+
+
+class PartialResultsStepTest {
+
+    private val httpClient: ConnectorHttpClient = mockk()
+    private val step = PartialResultsStep(httpClient)
+
+    @Test
+    fun `should return StepSuccess when execute successfully`(){
+        every {
+            httpClient.get(endpoint = "endpoint", headers = defaultHeaders)
+        } returns ConnectorHttpResponse(
+            responseContentType = null,
+            statusCode = HttpURLConnection.HTTP_OK,
+            headers = emptyMap(),
+            body = "SUCCESS RESPONSE",
+            isSuccessful = true
+        )
+
+        val expected = StepSuccess(payload = "SUCCESS RESPONSE", headers = emptyMap())
+        val actual = step.doRequest(
+            PartialResultsExtractorRequest(
+                endpoint = "endpoint",
+                sessionId = "sessionId",
+                etts = "etts"
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should return StepError when not execute successfully`() {
+        every {
+            httpClient.get(endpoint = "endpoint", headers = defaultHeaders)
+        } returns ConnectorHttpResponse(
+            responseContentType = null,
+            statusCode = HttpURLConnection.HTTP_BAD_REQUEST,
+            headers = emptyMap(),
+            body = "ERROR RESPONSE",
+            isSuccessful = false
+        )
+
+        val expected = StepError(payload = "ERROR RESPONSE")
+        val actual = step.doRequest(
+            PartialResultsExtractorRequest(
+                endpoint = "endpoint",
+                sessionId = "sessionId",
+                etts = "etts"
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    companion object {
+        val defaultHeaders = mapOf(
+            "Cookie" to "sessionId; ECS=S; etts",
+        )
+    }
+
+}


### PR DESCRIPTION
Add partial results extraction by cpf, password, year, term, course and subject. 

Exemplo:

```json
{
  "studentName": "Mário Luiz Frainer Fronza",
  "partialResults": {
    "period": "2020/2",
    "course": "Engenharia de Software",
    "subjectName": "subjectName",
    "results": [
      {
        "code": "A1",
        "resultName": "Produção de vídeo",
        "date": "26/11/2020",
        "classLoad": 9.3,
        "result": 10.0
      },
    ]
  }
}
```